### PR TITLE
Set TMPDIR to /var/tmp (FP <1.11.1) or /tmp (FP >=1.11.1) to ensure we are within sun_path limit

### DIFF
--- a/src/cobalt-host.h
+++ b/src/cobalt-host.h
@@ -6,6 +6,7 @@
 
 #include <glib.h>
 
+typedef struct SemVer SemVer;
 typedef struct CobaltHost CobaltHost;
 
 CobaltHost *cobalt_host_new();
@@ -21,5 +22,7 @@ gboolean cobalt_host_get_zypak_available(CobaltHost *host, gboolean *available,
                                          GError **error);
 gboolean cobalt_host_get_expose_pids_available(CobaltHost *host, gboolean *available,
                                                GError **error);
+gboolean cobalt_host_get_slash_tmp_shared_available(CobaltHost *host, gboolean *available,
+                                                    GError **error);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(CobaltHost, cobalt_host_free)


### PR DESCRIPTION
If TMPDIR is set to something that's ~61 characters long, Chromium
will crash. Below is the stacktrace:

```
0  0x000055555d22591e in base::ImmediateCrash () at ../../base/immediate_crash.h:176
1  logging::CheckFailure () at ../../base/check.h:211
2  (anonymous namespace)::SetupSocket (path=..., sock=0x1b2000254ca8, addr=0x7fffffffc9f0, socklen=<optimized out>) at ../../chrome/browser/process_singleton_posix.cc:302
3  ProcessSingleton::Create (this=0x1b2000254c30) at ../../chrome/browser/process_singleton_posix.cc:1068
4  ProcessSingleton::NotifyOtherProcessWithTimeoutOrCreate (this=0x1b2000254c30, command_line=..., retry_attempts=20, timeout=...) at ../../chrome/browser/process_singleton_posix.cc:967
5  0x0000555558067489 in ProcessSingleton::NotifyOtherProcessOrCreate (this=0x14) at ../../chrome/browser/process_singleton_posix.cc:943
6  ChromeProcessSingleton::NotifyOtherProcessOrCreate (this=0x1b2000254c00) at ../../chrome/browser/chrome_process_singleton.cc:29
7  (anonymous namespace)::AcquireProcessSingleton (user_data_dir=...) at ../../chrome/app/chrome_main_delegate.cc:567
8  ChromeMainDelegate::PostEarlyInitialization (this=0x7fffffffd270, invoked_in=...) at ../../chrome/app/chrome_main_delegate.cc:842
9  0x000055555c622d4f in content::ContentMainRunnerImpl::RunBrowser (this=0x1b200025c000, main_params=..., start_minimal_browser=<optimized out>)
    at ../../content/app/content_main_runner_impl.cc:1209
10 content::ContentMainRunnerImpl::Run (this=0x1b200025c000) at ../../content/app/content_main_runner_impl.cc:1144
11 0x000055555c61fa06 in content::RunContentProcess (content_main_runner=0x1b200025c000, params=...) at ../../content/app/content_main.cc:335
12 content::ContentMain (params=...) at ../../content/app/content_main.cc:348
13 0x0000555558066cf3 in ChromeMain (argc=<optimized out>, argv=<optimized out>) at ../../chrome/app/chrome_main.cc:192
14 0x00007ffff643b08a in __libc_start_call_main () at /usr/lib/x86_64-linux-gnu/libc.so.6
15 0x00007ffff643b14b in __libc_start_main () at /usr/lib/x86_64-linux-gnu/libc.so.6
16 0x0000555557b48025 in _start () at ../sysdeps/x86_64/start.S:115
```

This is because sun_path could be max 108 bytes including \0
and some app IDs might cause this limit to be exceeded.

We set /tmp (ramdisk) if FP version is >=1.11.1 or /var/tmp
(persistent) if FP version is <1.11.1. We don't care
about the persistance aspect, only that the TMPDIR is shared
between all instances of an app ID. Reference for when /tmp
became shared between all instances is available here:
https://github.com/flatpak/flatpak/commit/b65b3f6eadd51bd6600df2c0d07f902a552163d2

This issue is not theoretical and actually blocked:
https://github.com/flathub/flathub/pull/5098