### PR TITLE
Set CHROME_DESKTOP to the appropriate value

### DIFF
--- a/src/cobalt-launcher.c
+++ b/src/cobalt-launcher.c
@@ -291,6 +291,9 @@ static gboolean launcher_update_environment(CobaltLauncher *launcher, GError **e
       "~/.icons:/app/share/icons:/usr/share/icons:/usr/share/pixmaps"
       ":/usr/share/runtime/share/icons:/run/host/user-share/icons:/run/host/share/icons");
 
+  g_autofree char *chrome_desktop = g_strdup_printf("%s.desktop", app_id);
+  launcher_setenv("CHROME_DESKTOP", chrome_desktop);
+
   launcher_setenv("CHROME_WRAPPER", launcher->wrapper_script);
 
   if (launcher->sandbox_filename != NULL) {


### PR DESCRIPTION
This value should always be `<app_id>.desktop`. Not setting this
is known to cause weird issues with wrong icons being displayed
by the DE (`chromium-browser` icon shown instead of the actual
browser icon under certain circumstances) and causes the icon
to not show up for a couple of seconds under GNOME Wayland
when Chromium is not configured to use Wayland with the
`--ozone-platform=wayland` flag.